### PR TITLE
mistune 2.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.8.4" %}
+{% set version = "2.0.2" %}
 
 package:
   name: mistune
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/m/mistune/mistune-{{ version }}.tar.gz
-  sha256: 59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e
+  sha256: 6fc88c3cb49dba8b16687b41725e661cf85784c12e8974a29b9d336dd596c3a1
 
 build:
   number: 1000

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,6 @@ test:
   requires:
     - pytest-cov
     - pip
-    - python <3.10
   imports:
     - mistune
     - mistune.plugins

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,43 +9,46 @@ source:
   sha256: 6fc88c3cb49dba8b16687b41725e661cf85784c12e8974a29b9d336dd596c3a1
 
 build:
-  number: 1000
-  script: python -m pip install --no-deps --ignore-installed .
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
-  build:
-    - {{ compiler('c') }}
   host:
-    - cython
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
+  run_constrained:
+    # 6.1.0 pins to mistune <2 (a future version may loosen this pin)
+    # see: https://github.com/conda-forge/nbconvert-feedstock/pull/54
+    - nbconvert >6.1.0
 
 test:
   source_files:
     - tests
   requires:
-    - nose
-    - python
+    - pytest-cov
+    - pip
+    - python <3.10
   imports:
     - mistune
+    - mistune.plugins
+    - mistune.directives
   commands:
-    - nosetests
+    - pip check
+    - pytest --cov mistune --cov-report=term-missing:skip-covered --cov-fail-under=98 --no-cov-on-fail
 
 about:
   home: https://github.com/lepture/mistune
   license_file: LICENSE
-  license: BSD 3-Clause
+  license: BSD-3-Clause
   license_family: BSD
-  summary: 'The fastest markdown parser in pure Python.'
-  description: |
-    Inspired by https://github.com/chjj/marked, Mistune is the fastest markdown
-    parser in pure Python with renderer features. More features include table,
-    footnotes, autolink, fenced code etc.
+  summary: A sane Markdown parser with useful plugins and renderers.
   dev_url: https://github.com/lepture/mistune
-  doc_url: https://mistune.readthedocs.io/
-  doc_source_url: https://github.com/lepture/mistune/blob/master/README.rst
+  doc_url: https://mistune.readthedocs.io
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Update mistune to 2.0.2

Version change: bump version number from 0.8.4 to 2.0.2
Bug Tracker: new open issues https://github.com/lepture/mistune/issues
Github cnahgelog:  https://github.com/lepture/mistune/blob/master/docs/changes.rst and https://github.com/lepture/mistune/releases/tag/v2.0.2
Upstream license:  License file:  https://github.com/lepture/mistune/blob/master/LICENSE
Upstream setup.cfg:  https://github.com/lepture/mistune/blob/v2.0.2/setup.cfg
Upstream pyproject.toml:  https://github.com/lepture/mistune/blob/v2.0.2/pyproject.toml

The package mistune is mentioned inside the packages:
nbconvert |

Versions used by other packages
'>=0.8.1,<2':
- nbconvert 6.1.0

Actions:
1. Use `noarch: python`
2. Reset build number to `0`
3. Remove `compiler` from `build` and `cython` from `host`
4. Add missing `setuptools` and `wheel` in `host`
5. Add `run_constrained`:` nbconvert >6.1.0`
6. Update test/requires and test/imports
7. Add `pip check` and `pytest`
8. Fix license name

Result:
- all-succeeded