### PR TITLE
Rebuild mistune 0.8.4 for python 3.10 support

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.2" %}
+{% set version = "0.8.4" %}
 
 package:
   name: mistune
@@ -6,48 +6,47 @@ package:
 
 source:
   url: https://pypi.io/packages/source/m/mistune/mistune-{{ version }}.tar.gz
-  sha256: 6fc88c3cb49dba8b16687b41725e661cf85784c12e8974a29b9d336dd596c3a1
+  sha256: 59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e
 
 build:
-  noarch: python
-  number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  number: 1000
+  # trigger 1
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
+  build:
+    - {{ compiler('c') }}
   host:
+    - cython
     - python
     - pip
-    - setuptools
-    - wheel
   run:
     - python
-  run_constrained:
-    # 6.1.0 pins to mistune <2 (a future version may loosen this pin)
-    # see: https://github.com/conda-forge/nbconvert-feedstock/pull/54
-    - nbconvert >6.1.0
 
 test:
   source_files:
     - tests
   requires:
-    - pytest-cov
-    - pip
+    - nose
+    - python
   imports:
     - mistune
-    - mistune.plugins
-    - mistune.directives
   commands:
-    - pip check
-    - pytest --cov mistune --cov-report=term-missing:skip-covered --cov-fail-under=98 --no-cov-on-fail
+    - nosetests
 
 about:
   home: https://github.com/lepture/mistune
   license_file: LICENSE
-  license: BSD-3-Clause
+  license: BSD 3-Clause
   license_family: BSD
-  summary: A sane Markdown parser with useful plugins and renderers.
+  summary: 'The fastest markdown parser in pure Python.'
+  description: |
+    Inspired by https://github.com/chjj/marked, Mistune is the fastest markdown
+    parser in pure Python with renderer features. More features include table,
+    footnotes, autolink, fenced code etc.
   dev_url: https://github.com/lepture/mistune
-  doc_url: https://mistune.readthedocs.io
+  doc_url: https://mistune.readthedocs.io/
+  doc_source_url: https://github.com/lepture/mistune/blob/master/README.rst
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
 about:
   home: https://github.com/lepture/mistune
   license_file: LICENSE
-  license: BSD 3-Clause
+  license: BSD-3-Clause
   license_family: BSD
   summary: 'The fastest markdown parser in pure Python.'
   description: |


### PR DESCRIPTION
`nbconvert >=6.1` requires `mistune <2` but ppc64le hasn't python 3.10 support