### PR TITLE
Rebuild mistune 0.8.4 for python 3.10 support on ppc64le

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 1000
+  # trigger !
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 1000
-  # trigger !
+  # trigger 1
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:


### PR DESCRIPTION
nbconvert greater than v6.1 requires `mistune <2` https://github.com/AnacondaRecipes/nbconvert-feedstock/blob/aa99e7e9c88e8ca00a4ac043083a6b330f026042/recipe/meta.yaml#L27 but we are missing the mistune 0.8.4 artifact for python 3.10 on ppc64le.