### PR TITLE
mistune 2.0.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.2" %}
+{% set version = "2.0.4" %}
 
 package:
   name: mistune
@@ -6,10 +6,9 @@ package:
 
 source:
   url: https://pypi.io/packages/source/m/mistune/mistune-{{ version }}.tar.gz
-  sha256: 6fc88c3cb49dba8b16687b41725e661cf85784c12e8974a29b9d336dd596c3a1
+  sha256: 9ee0a66053e2267aba772c71e06891fa8f1af6d4b01d5e84e267b4570d4d9808
 
 build:
-  noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 


### PR DESCRIPTION
Addressing CVE-2022-34749 (it only applies to v2.0.x), see  https://github.com/lepture/mistune/commit/a6d43215132fe4f3d93f8d7e90ba83b16a0838b2 and https://github.com/lepture/mistune/issues/314#issuecomment-1223972386

Bug Tracker: new open issues https://github.com/lepture/mistune/issues
Changelog: https://github.com/lepture/mistune/blob/master/docs/changes.rst
Releases: https://github.com/lepture/mistune/releases
License: https://github.com/lepture/mistune/blob/v2.0.4/LICENSE
Requirements: 
- https://github.com/lepture/mistune/blob/v2.0.4/pyproject.toml
- https://github.com/lepture/mistune/blob/v2.0.4/setup.cfg

Actions:
1. Remove `noarch: python`